### PR TITLE
feat: use dom to get code contents

### DIFF
--- a/src/gatsby-browser.ts
+++ b/src/gatsby-browser.ts
@@ -1,11 +1,11 @@
 import './styles.css';
 
 export const onClientEntry = () => {
-  window.gatsbyRemarkCopyToClipboard = async (str, copyButtonDom) => {
+  window.gatsbyRemarkCopyToClipboard = async (copyButtonDom, codeBlockDom) => {
     if (copyButtonDom.textContent === 'Copied') {
       return;
     }
-    navigator.clipboard.writeText(str);
+    navigator.clipboard.writeText(codeBlockDom.textContent || '');
 
     copyButtonDom.classList.add('copied');
     copyButtonDom.textContent = 'Copied!';

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,6 +1,6 @@
 interface Window {
   gatsbyRemarkCopyToClipboard: (
-    str: string,
     copyButtonDom: HTMLElement,
+    codeBlockDom: HTMLElement,
   ) => Promise<void>;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,17 +27,11 @@ export default function gatsbyRemarkPrismCopyButton(
       .filter(Boolean)
       .join(' ');
 
-    let code = parent.children[index || 0].value;
-    code = code
-      .replace(/"/gm, '&quot;')
-      .replace(/`/gm, '\\`')
-      .replace(/\$/gm, '\\$');
-
     const buttonNode = {
       type: 'html',
       value: `
           <div class="${buttonContainerClass}">
-            <div class="${buttonClass}" tabindex="0" role="button" aria-pressed="false" onclick="gatsbyRemarkCopyToClipboard(\`${code}\`, this)">
+            <div class="${buttonClass}" tabindex="0" role="button" aria-pressed="false" onclick="gatsbyRemarkCopyToClipboard(this, this.parentNode.nextElementSibling)">
               Copy
             </div>
           </div>


### PR DESCRIPTION
- pass code block's dom instead of code content to `gatsbyRemarkCopyToClipboard`
- get code content from dom to avoid escape problem

close #3 #2 